### PR TITLE
로그아웃 시 Refresh Token이 삭제되지 않은 문제

### DIFF
--- a/src/main/java/org/mansumugang/mansumugang_service/service/auth/LogoutService.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/service/auth/LogoutService.java
@@ -41,7 +41,7 @@ public class LogoutService {
 
         // 정상로직 3.
         // savedAccessToken 이 존재한다면 redis 에서 refreshToken 삭제
-        valueOperations.getAndDelete(savedAccessToken);
+        valueOperations.getAndDelete(resolvedRefreshToken);
     }
 
 }


### PR DESCRIPTION
로그아웃 시 Refresh Token이 삭제되지 않은 문제를 해결했습니다.

이슈번호 #26 