### PR TITLE
42번 이슈에 대한 코드 작성 완료

### DIFF
--- a/src/main/java/org/mansumugang/mansumugang_service/constant/ErrorType.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/constant/ErrorType.java
@@ -39,8 +39,8 @@ public enum ErrorType {
     UserNotFoundError(
             HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."
     ),
-    RelationDismatchError(
-            HttpStatus.NOT_FOUND, "보호자의 환자 명단에서 해당 환자를 찾을 수 없습니다."
+    UserTypeDismatchError(
+            HttpStatus.NOT_FOUND, "해당 유저는 보호자가 아닌 환자입니다."
     ),
 
     // ----- Location ------

--- a/src/main/java/org/mansumugang/mansumugang_service/controller/auth/AuthController.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/controller/auth/AuthController.java
@@ -62,9 +62,18 @@ public class AuthController {
         // 아이디 중복 확인
         signUpService.checkUsernameDuplication(usernameDuplicationCheckDto);
 
-        // 성공 로직(responeDto 로 변환 및 반환)
+        // 성공 로직(responseDto 로 변환 및 반환)
         return new ResponseEntity<>(new UsernameDuplicationCheckResponseDto(), HttpStatus.OK);
 
+    }
+
+    @PostMapping("/check/protectorUsername")
+    public ResponseEntity<ProtectorUsernameCheckResponseDto> checkProtectorUsername(
+            @Valid @RequestBody ProtectorUsernameCheckRequestDto protectorUsernameCheckRequestDto
+    ){
+        signUpService.checkProtectorUsername(protectorUsernameCheckRequestDto);
+
+        return new ResponseEntity<>(new ProtectorUsernameCheckResponseDto(), HttpStatus.OK);
     }
 
     @PostMapping("/check/nickname") // 유저 닉네임 중복확인 버튼

--- a/src/main/java/org/mansumugang/mansumugang_service/domain/user/Patient.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/domain/user/Patient.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class Patient extends User {
 
     // Protector 와의 관계 정의
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "protector_id", nullable = false)
     private Protector protector;
 

--- a/src/main/java/org/mansumugang/mansumugang_service/domain/user/UserLocation.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/domain/user/UserLocation.java
@@ -33,7 +33,7 @@ public class UserLocation {
     private LocalDateTime createdAt;
 
     // Patient 와의 관계 정의
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "patient_id", nullable = false)
     private Patient patient;
 

--- a/src/main/java/org/mansumugang/mansumugang_service/dto/auth/signup/ProtectorUsernameCheckRequestDto.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/dto/auth/signup/ProtectorUsernameCheckRequestDto.java
@@ -1,0 +1,17 @@
+package org.mansumugang.mansumugang_service.dto.auth.signup;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ProtectorUsernameCheckRequestDto {
+
+    @NotBlank(message = "아이디는 공백일 수 없습니다.")
+    @Size(min = 4, max = 16, message = "아이디는 4 ~ 16자리로 입력해주세요")
+    @Pattern(regexp = "^[A-Za-z0-9]+$", message = "아이디는 영어 소/대문자 및 숫자로 이루어져야합니다.")
+    String username;
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/dto/auth/signup/ProtectorUsernameCheckResponseDto.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/dto/auth/signup/ProtectorUsernameCheckResponseDto.java
@@ -1,0 +1,15 @@
+package org.mansumugang.mansumugang_service.dto.auth.signup;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ProtectorUsernameCheckResponseDto {
+    String message;
+
+    public ProtectorUsernameCheckResponseDto() {
+        this.message = "해당 아이디는 보호자가 맞습니다.";
+    }
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/service/auth/SignupService.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/service/auth/SignupService.java
@@ -15,6 +15,7 @@ import org.mansumugang.mansumugang_service.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -94,6 +95,22 @@ public class SignupService {
             throw new CustomErrorException(ErrorType.DuplicatedUsernameError);
 
         }
+    }
+
+    public void checkProtectorUsername(ProtectorUsernameCheckRequestDto protectorUsernameCheckRequestDto){
+
+        // 1. userRepository 에서 requestDto 로 받은 아이디로 해당 유저 존재하는지 확인 없으면 에러 발생.
+        Optional<User> foundUser = userRepository.findByUsername(protectorUsernameCheckRequestDto.getUsername());
+
+        if (foundUser.isEmpty()){
+            throw new CustomErrorException(ErrorType.UserNotFoundError);
+        }
+
+        // 2. 찾은 유저의 userType 이 User_protector 라면 패스, User_patient 라면 오류 발생.
+        if (Objects.equals(foundUser.get().getUsertype(), "User_patient")){
+            throw new CustomErrorException(ErrorType.UserTypeDismatchError);
+        }
+
     }
 
     public void checkNicknameDuplication(NicknameDuplicationCheckDto nicknameDuplicationCheckDto){


### PR DESCRIPTION
코드 작성 세부사항은 다음과 같습니다.
1. 환자 회원 가입 시 보호자 아이디를 기입하여야하는데 기입한 아이디가 보호자가 맞는지 검증하는 API 구현
- 1.1. 서버로 넘겨받은 아이디를 userRepository에서 찾아서 User 객체로 반환하여 해당 객체가 비었다면 에러를 반환합니다.
- 1.2. 에러가 발생하지 않았다면, 해당 객체의 usertype이 User_patient 인지 User_protector 인지 확인하고, User_patient라면 오류를 반환합니다.
- 1.3. 에러가 발생하지 않았다면(usertype이 User_protector 라면) 응답으로 정상 작동 메시지와, HTTP 200 코드를 보냅니다.

2. JPA를 통해 엔티티간 다대일 관계에 대해서 수정하였습니다.
- 2.1. 기존에는 ManyToOne 애노테이션의  fetch 속성의 값으로 기본값을 넣어주었지만, 성능을 고려하여 fetch 속성에 FetchType.Lazy 로 값을 주었습니다.