### PR TITLE
보호자 메인페이지 - 보호자의 환자 찾기 구현

### DIFF
--- a/src/main/java/org/mansumugang/mansumugang_service/controller/user/UserController.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/controller/user/UserController.java
@@ -1,0 +1,32 @@
+package org.mansumugang.mansumugang_service.controller.user;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mansumugang.mansumugang_service.domain.user.User;
+import org.mansumugang.mansumugang_service.dto.user.PatientInquiry;
+import org.mansumugang.mansumugang_service.service.user.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/inquiry/patients")
+    public ResponseEntity<PatientInquiry.Response> getPatientsByProtector(@AuthenticationPrincipal User user){
+
+        PatientInquiry.Dto foundAllPatients = userService.getPatientsByProtector(user);
+
+        return ResponseEntity.ok(PatientInquiry.Response.createNewResponse(foundAllPatients));
+    }
+
+
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/dto/user/PatientInquiry.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/dto/user/PatientInquiry.java
@@ -1,0 +1,60 @@
+package org.mansumugang.mansumugang_service.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.mansumugang.mansumugang_service.domain.user.Patient;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PatientInquiry {
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class PatientElement{
+
+        private Long patientId;
+        private String patientUsername;
+        private String patientName;
+
+        public static PatientElement fromEntity(Patient patient){
+            return PatientElement.builder()
+                    .patientId(patient.getId())
+                    .patientUsername(patient.getUsername())
+                    .patientName(patient.getName())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Dto{
+
+        private List<PatientElement> patients;
+
+        public static Dto fromEntity(List<Patient> foundPatients){
+            return Dto.builder()
+                    .patients(foundPatients.stream()
+                            .map(patient -> PatientElement.fromEntity(patient))
+                            .collect(Collectors.toList()))
+                    .build();
+        }
+
+    }
+
+    @Getter
+    @Builder
+    public static class Response{
+
+        private List<PatientElement> patients;
+
+        public static Response createNewResponse(Dto dto){
+            return Response.builder()
+                    .patients(dto.getPatients())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/service/user/UserService.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/service/user/UserService.java
@@ -1,0 +1,62 @@
+package org.mansumugang.mansumugang_service.service.user;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mansumugang.mansumugang_service.constant.ErrorType;
+import org.mansumugang.mansumugang_service.domain.user.Patient;
+import org.mansumugang.mansumugang_service.domain.user.Protector;
+import org.mansumugang.mansumugang_service.domain.user.User;
+import org.mansumugang.mansumugang_service.dto.user.PatientInquiry;
+import org.mansumugang.mansumugang_service.exception.CustomErrorException;
+import org.mansumugang.mansumugang_service.repository.PatientRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final PatientRepository patientRepository;
+
+    public PatientInquiry.Dto getPatientsByProtector(User user){
+
+        // 1. AuthenticationPrincipal 로 넘겨받은 user 가 보호자 객체인지 검증
+        Protector validProtector = validateProtector(user);
+
+        // 2. 검증된 보호자 객체로 보호자의 환자 찾기.
+        List<Patient> foundPatients = getAllPatientsByProtectorId(validProtector);
+
+        return PatientInquiry.Dto.fromEntity(foundPatients);
+
+    }
+
+
+
+    private Protector validateProtector(User user) {
+
+        if (user == null){
+            throw new CustomErrorException(ErrorType.UserNotFoundError);
+        }
+
+        if(user instanceof Protector){
+            return (Protector) user;
+        }
+
+        throw new CustomErrorException(ErrorType.AccessDeniedError);
+    }
+
+
+    private List<Patient> getAllPatientsByProtectorId(Protector validProtector) {
+        List<Patient> foundPatients = patientRepository.findByProtector_id(validProtector.getId());
+
+        if (foundPatients.isEmpty()){
+            throw new CustomErrorException(ErrorType.UserNotFoundError);
+        }
+
+        return foundPatients;
+    }
+}


### PR DESCRIPTION
구현 로직은 다음과 같습니다.
- 1. 보호자의 엑세스 토큰을 넘겨받아서 서버에서 보호자 객체가 맞는지 확인합니다.
- 2. 유효한 보호자라면 해당 보호자의 고유번호를 가진 환자를 찾습니다. 
- 3. 찾은 모든 환자의 고유번호, 아이디, 이름을 응답객체에 List로 담아서 클라이언트로 보냅니다.