### PR TITLE
FCM을 이용한 웹 푸시 알림 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ out/
 ### Static ###
 **/src/main/resources/static/
 
+### Friebase ###
+src/main/resources/firebase/mansumugang-service-firebase-adminsdk-22kx1-d73706ff32.json
+
 ### macOS ###
 # General
 .DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,13 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
 	testImplementation 'org.mockito:mockito-core:5.12.0' // Mockito 의존성 추가
 	implementation 'com.mpatric:mp3agic:0.9.1' // mp3파일 재생시간 추출 위해서 추가
+
+	implementation 'com.google.firebase:firebase-admin:9.2.0'           // Google Firebase Admin
+	implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'     // Jackson Data Bind
+
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 

--- a/src/main/java/org/mansumugang/mansumugang_service/config/FirebaseConfig.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/config/FirebaseConfig.java
@@ -1,0 +1,42 @@
+package org.mansumugang.mansumugang_service.config;
+
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ResourceUtils;
+
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+
+    /**
+     * FCM 설정
+     * ClassPathResource : Resource 폴더 이하 파일 경로 부터 읽음. -> 현재 비공개 엑세스 키 파일(Json) 경로 == resources/firebase/파일명.json
+     */
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        FileInputStream aboutFirebaseFile = new FileInputStream(String.valueOf(ResourceUtils.getFile("./src/main/resources/firebase/mansumugang-service-firebase-adminsdk-22kx1-d73706ff32.json")));
+
+        FirebaseOptions options = FirebaseOptions
+                .builder()
+                .setCredentials(GoogleCredentials.fromStream(aboutFirebaseFile))
+                .build();
+        return FirebaseApp.initializeApp(options);
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/config/SecurityConfig.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/config/SecurityConfig.java
@@ -34,7 +34,6 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final RedisTemplate<String, String> redisTemplate;
 
-
     @Bean
     public LoginSuccessHandler loginSuccessHandler() {
         return new LoginSuccessHandler(redisTemplate, jwtTokenProvider);

--- a/src/main/java/org/mansumugang/mansumugang_service/controller/fcm/FcmController.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/controller/fcm/FcmController.java
@@ -1,0 +1,41 @@
+package org.mansumugang.mansumugang_service.controller.fcm;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mansumugang.mansumugang_service.domain.user.User;
+import org.mansumugang.mansumugang_service.dto.fcm.FcmMessage;
+import org.mansumugang.mansumugang_service.dto.fcm.FcmTokenSave;
+import org.mansumugang.mansumugang_service.service.fcm.FcmService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/fcm")
+public class FcmController {
+
+    private final FcmService fcmService;
+
+    @PostMapping("/token/save")
+    public ResponseEntity<FcmTokenSave.Response> fcmTokenSave(@AuthenticationPrincipal User user,
+                                                              @RequestBody FcmTokenSave.Request request
+    ){
+        log.info("컨트롤러 호출");
+        fcmService.saveFcmToken(user, request);
+
+        return ResponseEntity.ok(FcmTokenSave.Response.createNewResponse());
+    }
+
+//    @PostMapping("/message")
+//    public ResponseEntity<FcmMessage.Response> sendMessage() {
+//        fcmService.sendMessage(Message);
+//        return new ResponseEntity<>(FcmMessage.Response.createNewResponse(), HttpStatus.CREATED);
+//    }
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/domain/fcm/FcmToken.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/domain/fcm/FcmToken.java
@@ -1,0 +1,54 @@
+package org.mansumugang.mansumugang_service.domain.fcm;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.mansumugang.mansumugang_service.domain.user.Protector;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+
+@Entity
+@Getter
+@Setter
+@Table(name = "userFcmToken")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class FcmToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "token_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String fcmToken;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+
+    // Protector 와의 관계 정의
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "protector_id", nullable = false)
+    private Protector protector;
+
+    private FcmToken(Long id, String fcmToken, LocalDateTime createdAt, Protector protector) {
+        this.id = id;
+        this.fcmToken = fcmToken;
+        this.createdAt = createdAt;
+        this.protector = protector;
+    }
+
+    public static FcmToken of(String validFcmToken,
+                              Protector validProtector
+    ){
+        return FcmToken.builder()
+                .fcmToken(validFcmToken)
+                .protector(validProtector)
+                .build();
+    }
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/domain/hospital/Hospital.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/domain/hospital/Hospital.java
@@ -50,6 +50,8 @@ public class Hospital {
 
     private LocalDateTime actualHospitalVisitingTime;
 
+    private Boolean isPushed;
+
 
     public static Hospital of(HospitalSave.Request requestDto, Patient patient, LocalDateTime filteredLocalDateTime){
         return Hospital.builder()
@@ -60,6 +62,7 @@ public class Hospital {
                 .longitude(requestDto.getLongitude())
                 .hospitalDescription(requestDto.getHospitalDescription())
                 .hospitalVisitingTime(filteredLocalDateTime)
+                .isPushed(false)
                 .build();
     }
 }

--- a/src/main/java/org/mansumugang/mansumugang_service/dto/auth/login/LoginRequestDto.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/dto/auth/login/LoginRequestDto.java
@@ -11,6 +11,4 @@ public class LoginRequestDto {
 
     @NotNull(message = "비밀번호를 입력해주세요!")
     private String password;
-
-
 }

--- a/src/main/java/org/mansumugang/mansumugang_service/dto/fcm/FcmMessage.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/dto/fcm/FcmMessage.java
@@ -1,0 +1,22 @@
+package org.mansumugang.mansumugang_service.dto.fcm;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class FcmMessage {
+
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Response{
+        private String message;
+
+        public static Response createNewResponse(){
+            return Response.builder()
+                    .message("메시지 전송 완료")
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/dto/fcm/FcmTokenSave.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/dto/fcm/FcmTokenSave.java
@@ -1,0 +1,39 @@
+package org.mansumugang.mansumugang_service.dto.fcm;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.mansumugang.mansumugang_service.domain.user.Protector;
+
+public class FcmTokenSave {
+
+    @Getter
+    @Setter
+    @Builder
+    public static class Request{
+
+        @NotNull
+        private String fcmToken;
+
+        @NotNull
+        private Protector protector;
+
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class Response{
+        private String message;
+
+        public static Response createNewResponse(){
+            return Response.builder()
+                    .message("FCM 토큰이 저장완료되었습니다.")
+                    .build();
+        }
+    }
+
+
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/repository/FcmTokenRepository.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/repository/FcmTokenRepository.java
@@ -1,0 +1,22 @@
+package org.mansumugang.mansumugang_service.repository;
+
+import org.mansumugang.mansumugang_service.domain.fcm.FcmToken;
+import org.mansumugang.mansumugang_service.domain.user.Protector;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE FcmToken f SET f.fcmToken = :fcmToken WHERE f.protector = :protector")
+    void updateFcmToken(Protector protector, String fcmToken);
+
+
+    List<FcmToken> findByProtectorId(Long userId);
+
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/repository/HospitalRepository.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/repository/HospitalRepository.java
@@ -3,6 +3,8 @@ package org.mansumugang.mansumugang_service.repository;
 import org.mansumugang.mansumugang_service.domain.hospital.Hospital;
 import org.mansumugang.mansumugang_service.domain.user.Patient;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,4 +14,13 @@ public interface HospitalRepository extends JpaRepository<Hospital, Long> {
     List<Hospital> findAllByPatientIdAndHospitalVisitingTimeBetween(Long patientId, LocalDateTime hospitalVisitingTime, LocalDateTime hospitalVisitingTime2);
 
     Optional<Hospital> findByPatientAndHospitalVisitingTime(Patient patient, LocalDateTime hospitalVisitingTime);
+
+//    @Query("SELECT h FROM Hospital h WHERE " +
+//            "h.status = false AND " +
+//            "h.isPushed = false AND " +
+//            ":overdueTime >= h.hospitalVisitingTime ")
+//    List<Hospital> findHospitalsWithConditions(@Param("overdueTime") LocalDateTime overdueTime);
+
+    List<Hospital> findByStatusAndIsPushedAndHospitalVisitingTimeBefore(Boolean status, Boolean isPushed, LocalDateTime graceTime);
+
 }

--- a/src/main/java/org/mansumugang/mansumugang_service/service/fcm/FcmService.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/service/fcm/FcmService.java
@@ -1,0 +1,79 @@
+package org.mansumugang.mansumugang_service.service.fcm;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.mansumugang.mansumugang_service.constant.ErrorType;
+import org.mansumugang.mansumugang_service.domain.fcm.FcmToken;
+import org.mansumugang.mansumugang_service.domain.user.Protector;
+import org.mansumugang.mansumugang_service.domain.user.User;
+import org.mansumugang.mansumugang_service.dto.fcm.FcmTokenSave;
+import org.mansumugang.mansumugang_service.exception.CustomErrorException;
+import org.mansumugang.mansumugang_service.repository.FcmTokenRepository;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final FcmTokenRepository fcmTokenRepository;
+
+    @Transactional
+    public void saveFcmToken(User user, FcmTokenSave.Request request){
+
+        log.info("서비스 호출");
+
+        // 1. 받은 user 가 Protector 인지 확인.
+        Protector validProtector = validateProtector(user);
+
+        // 2. 받아온 요청의 fcmToken 검증.
+        String validFcmToken = validateFcmToken(request);
+
+        // 3. 검증 완료시 DB에 저장
+        fcmTokenRepository.save(FcmToken.of(validFcmToken, validProtector));
+
+    }
+
+    public void sendMessage(Message message){
+//        String userIIDToken = "fGng3MP7GbkP3YpWJDm_rV:APA91bGHkfOTeS5Nsuu2lCW0zt5F6cTN81VuFQoIxuK40EkVbkQE6tVqwUCAtJ73QF87XUM0QxjnvopVhETTtnfIMIoyio8u0ojRQ4mHONd8d7Q_XyJ1V8WgxwddOjgIkaypGIE1YuDX";
+
+        try {
+            String response = firebaseMessaging.send(message);
+            log.info(response);
+        } catch (FirebaseMessagingException e) {
+            log.error(e.getMessage());
+
+            // TODO : 앱이 정상적으로 홈화면에 추가되지 않으면 푸시알림이 정상적으로 보내지지 않음. 이에 대한 예외처리가 필요함.
+        }
+    }
+
+    private Protector validateProtector(User user) {
+        log.info("AuthenticationPrincipal 로 받은 유저 객체가 보호자 객체인지 검증 시작");
+        if (user == null) {
+            throw new CustomErrorException(ErrorType.UserNotFoundError);
+        }
+
+        if (user instanceof Protector) {
+
+            log.info("보호자 객체 검증 완료");
+            return (Protector) user;
+        }
+
+        throw new CustomErrorException(ErrorType.AccessDeniedError);
+    }
+
+    private String validateFcmToken(FcmTokenSave.Request request){
+
+        String fcmToken = request.getFcmToken();
+        if(fcmToken == null){
+            throw new CustomErrorException(ErrorType.NotValidRequestError);
+        }
+
+        return fcmToken;
+    }
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/service/medicine/ScheduledTasks.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/service/medicine/ScheduledTasks.java
@@ -1,17 +1,25 @@
 package org.mansumugang.mansumugang_service.service.medicine;
 
+import com.google.firebase.messaging.Message;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.mansumugang.mansumugang_service.constant.ErrorType;
 import org.mansumugang.mansumugang_service.constant.InternalErrorType;
 import org.mansumugang.mansumugang_service.constant.MedicineRecordStatusType;
 import org.mansumugang.mansumugang_service.constant.MedicineStatusType;
+import org.mansumugang.mansumugang_service.domain.fcm.FcmToken;
+import org.mansumugang.mansumugang_service.domain.hospital.Hospital;
 import org.mansumugang.mansumugang_service.domain.medicine.MedicineIntakeDay;
 import org.mansumugang.mansumugang_service.domain.medicine.MedicineIntakeRecord;
+import org.mansumugang.mansumugang_service.domain.user.Patient;
+import org.mansumugang.mansumugang_service.domain.user.Protector;
 import org.mansumugang.mansumugang_service.dto.medicine.TodayMedicineScheduleResult;
+import org.mansumugang.mansumugang_service.exception.CustomErrorException;
 import org.mansumugang.mansumugang_service.exception.InternalErrorException;
-import org.mansumugang.mansumugang_service.repository.MedicineIntakeDayRepository;
-import org.mansumugang.mansumugang_service.repository.MedicineIntakeRecordRepository;
+import org.mansumugang.mansumugang_service.repository.*;
+import org.mansumugang.mansumugang_service.service.fcm.FcmService;
+import org.mansumugang.mansumugang_service.service.hospital.HospitalService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -19,15 +27,21 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class ScheduledTasks {
-    private final MedicineIntakeRecordRepository medicineIntakeRecordRepository;
-    ;
-    private final MedicineIntakeDayRepository medicineIntakeDayRepository;
+
     private final MedicineCommonService medicineCommonService;
+    private final HospitalService hospitalService;
+    private final FcmService fcmService;
+
+    private final MedicineIntakeRecordRepository medicineIntakeRecordRepository;
+    private final MedicineIntakeDayRepository medicineIntakeDayRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final HospitalRepository hospitalRepository;
 
     @Scheduled(fixedRate = 60000)
     @Transactional
@@ -70,25 +84,96 @@ public class ScheduledTasks {
                                 true
                         )
                 );
-               sendPushNotificationToProtector(medicineInfo);
+                sendPushNoTakenMedicineNotificationToProtector(medicineInfo);
             }
 
             // 약의 복용상태가 NO_TAKEN이고, push알림을 보내지 않은 경우(즉, MedicineIntakeRecord의 status를 TRUE -> FALSE 변경한 경우)
             // isPushed를 TRUE로 변경 후 알림 전송
             if (assignedMedicineStatus == MedicineStatusType.NO_TAKEN && !medicineInfo.getMedicineIntakeRecord().getIsPushed()) {
                 medicineInfo.getMedicineIntakeRecord().setIsPushed(true);
-                sendPushNotificationToProtector(medicineInfo);
+                sendPushNoTakenMedicineNotificationToProtector(medicineInfo);
             }
         }
     }
 
-    private void sendPushNotificationToProtector(TodayMedicineScheduleResult medicineInfo){
+    @Scheduled(fixedRate = 60000)
+    @Transactional
+    protected void checkHospitalUnvisitedPatient(){
+        // 병원 방문시간(HospitalVisitingTime) + 30분 시점부터 병원을 가지 않은 환자를 조회(핵심) status => false true
+        // 현재시간 >=  hospitalVisitingTime + 30 && status == false  && isPushed == false
+
+        LocalDateTime graceTime = LocalDateTime.now().minusMinutes(31);
+
+        // 1. 필요한 쿼리문 : hospital.status 가 false 인 모든 튜플을 추출(조건 : (hospital_visiting_time + 30분 - 현재시간)의 결과가 1분 이상  && isPushed 가 false 여야함.)
+        List<Hospital> hospitalUnvisitedPatientsInfos = hospitalRepository.findByStatusAndIsPushedAndHospitalVisitingTimeBefore(false, false, graceTime);
+
+
+        // 2. 가져온 튜플의 patient 객체 추출 -> 보호자 찾기.
+        for (Hospital hospitalUnvisitedPatientsInfo : hospitalUnvisitedPatientsInfos) {   // 환자 1, 2 , 3 -> 환자 1에대한 문자발송처리함. -> 환자 1의 보호자의 토큰을 검색함.(기존의 반환값이 리스트형임).
+
+           sendPushHospitalUnvisitedNotificationToProtector(hospitalUnvisitedPatientsInfo);
+           hospitalUnvisitedPatientsInfo.setIsPushed(true);
+        }
+
+
+        // 2. 알림보내기.
+    }
+
+
+    private void sendPushNoTakenMedicineNotificationToProtector(TodayMedicineScheduleResult medicineInfo){
         log.info("알림 전송: [환자 아이디: {}, 약 아이디: {}, 약 이름 :{}, 예정된 약 복용시간: {}]",
                 medicineInfo.getMedicine().getPatient().getId(),
                 medicineInfo.getMedicine().getId(),
                 medicineInfo.getMedicine().getMedicineName(),
                 medicineInfo.getTargetDate() + " " + medicineInfo.getMedicineInTakeTime().getMedicineIntakeTime().toString());
 
+
+
         // TODO: 보호자에게 약 미복용에 대한 push 알림기능 구현
+
+        /**
+         * 1. 지정된 시간에 약을 먹지않고, 유예시간(1시간) 이후에도 약을 복용하지 않은 유저를 1분 간격으로 검색. ->  checkMedicineNoTakenPatient() 메서드
+         * 2. 검색된 환자의 보호자를 검색 -> 보호자의 FCM Token 조회
+         * 3. FCM 백앤드로 메시지 전송
+         */
+
+        // 2번 로직.
+        Patient notTakenMedicinePatient = medicineInfo.getMedicine().getPatient();
+
+        List<FcmToken> foundTokens = fcmTokenRepository.findByProtectorId(notTakenMedicinePatient.getProtector().getId());
+        log.info(String.valueOf(foundTokens.size()));
+
+        for (FcmToken fcmToken : foundTokens) {
+            Message message = Message.builder()
+                    .putData("title", "약 미복용 알림")
+                    .putData("body", notTakenMedicinePatient.getName() + "님께서 " +medicineInfo.getMedicine().getMedicineName() + "을 복용하지 않으셨어요!")
+                    .setToken(fcmToken.getFcmToken())
+                    .build();
+
+            fcmService.sendMessage(message);
+        }
     }
+
+    private void sendPushHospitalUnvisitedNotificationToProtector(Hospital hospitalUnvisitedPatientsInfo){
+
+        String unVisitedHospitalPatient = hospitalUnvisitedPatientsInfo.getPatient().getName();
+        String hospitalName = hospitalUnvisitedPatientsInfo.getHospitalName();
+
+        List<FcmToken> foundTokens = fcmTokenRepository.findByProtectorId(hospitalUnvisitedPatientsInfo.getPatient().getProtector().getId());
+
+
+        log.info(String.valueOf(foundTokens.size()));
+
+        for (FcmToken fcmToken : foundTokens) {
+            Message message = Message.builder()
+                    .putData("title", "병원 미방문 알림")
+                    .putData("body", unVisitedHospitalPatient + "님께서 " + hospitalName + "에 방문하지 않으셨어요!")
+                    .setToken(fcmToken.getFcmToken())
+                    .build();
+
+            fcmService.sendMessage(message);
+        }
+    }
+
 }
+


### PR DESCRIPTION
기능 구현 상세 내용은 다음과 같습니다.
- FCM 백엔드와의 연결 구성(Firebase Admin SDK 초기화 등)
- 약 미복용 환자의 보호자에 대한 푸시알림 전송
- 병원 예약시간 + 유예기간(30분) 이후에도 병원에 미방문한 환자의 보호자에 대한 푸시 알림 전송