### PR TITLE
환자의 가족관계 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,13 @@ repositories {
 	mavenCentral()
 }
 
+configurations {
+	all {
+		exclude group: 'commons-logging', module: 'commons-logging'
+	}
+}
+
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/mansumugang/mansumugang_service/controller/user/UserController.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/controller/user/UserController.java
@@ -44,6 +44,16 @@ public class UserController {
         return ResponseEntity.ok(PatientInfoInquiry.Response.createNewResponse(foundOwnInfo));
     }
 
+    @GetMapping("/inquiry/familyMember")
+    public ResponseEntity<FamilyMemberInquiry.Response> getFamilyMember(@AuthenticationPrincipal User user){
+
+
+        FamilyMemberInquiry.Dto dto = userService.getFamilyMember(user);
+
+        return ResponseEntity.ok(FamilyMemberInquiry.Response.createNewResponse(dto));
+    }
+
+
     // 유저 정보 수정
     @PatchMapping("/protector/{id}")
     public ResponseEntity<ProtectorInfoUpdate.Response> updateProtectorInfo(@AuthenticationPrincipal User user,

--- a/src/main/java/org/mansumugang/mansumugang_service/dto/user/FamilyMember.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/dto/user/FamilyMember.java
@@ -1,0 +1,67 @@
+package org.mansumugang.mansumugang_service.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.mansumugang.mansumugang_service.domain.user.Patient;
+import org.mansumugang.mansumugang_service.domain.user.Protector;
+
+
+public class FamilyMember {
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Self{
+
+        private String name;
+        private String telephone;
+        private String usertype;
+
+        public static Self fromEntity(Patient validPatient){
+            return Self.builder()
+                    .name(validPatient.getName())
+                    .telephone(validPatient.getTelephone())
+                    .usertype(validPatient.getUsertype())
+                    .build();
+        }
+    }
+
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Nok{
+
+        private String name;
+        private String telephone;
+        private String usertype;
+
+        public static Nok fromEntity(Protector foundProtector){
+            return Nok.builder()
+                    .name(foundProtector.getName())
+                    .telephone(foundProtector.getTelephone())
+                    .usertype(foundProtector.getUsertype())
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class OtherPatient{
+
+        private String name;
+        private String telephone;
+        private String usertype;
+
+        public static OtherPatient fromEntity(Patient otherPatient){
+            return OtherPatient.builder()
+                    .name(otherPatient.getName())
+                    .telephone(otherPatient.getTelephone())
+                    .usertype(otherPatient.getUsertype())
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/org/mansumugang/mansumugang_service/dto/user/FamilyMemberInquiry.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/dto/user/FamilyMemberInquiry.java
@@ -1,0 +1,51 @@
+package org.mansumugang.mansumugang_service.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.mansumugang.mansumugang_service.domain.user.Patient;
+import org.mansumugang.mansumugang_service.domain.user.Protector;
+
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FamilyMemberInquiry {
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Dto{
+        private FamilyMember.Self self;
+        private FamilyMember.Nok protector;
+        private List<FamilyMember.OtherPatient> otherPatients;
+
+        public static Dto of(Patient validPatient, Protector foundProtector, List<Patient> otherPatients){
+            return Dto.builder()
+                    .self(FamilyMember.Self.fromEntity(validPatient))
+                    .protector(FamilyMember.Nok.fromEntity(foundProtector))
+                    .otherPatients((otherPatients.stream()
+                            .map(FamilyMember.OtherPatient::fromEntity)
+                            .collect(Collectors.toList())))
+                    .build();
+
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Response{
+        private FamilyMember.Self self;
+        private FamilyMember.Nok protector;
+        private List<FamilyMember.OtherPatient> otherPatients;
+
+        public static Response createNewResponse(Dto dto){
+            return Response.builder()
+                    .self(dto.getSelf())
+                    .protector(dto.getProtector())
+                    .otherPatients(dto.getOtherPatients())
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
로직은 다음과 같습니다. 
1. 환자 객체 검증
2. 환자의 보호자 찾기
3. 해당 보호자의 환자 리스트 찾기(가족관계를 조회하려는 환자는 제외)
4. 응답객체 반환