### PR TITLE
보호자 회원 탈퇴 기능 구현 완료

### DIFF
--- a/src/main/java/org/mansumugang/mansumugang_service/constant/ErrorType.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/constant/ErrorType.java
@@ -42,6 +42,10 @@ public enum ErrorType {
     UserTypeDismatchError(
             HttpStatus.NOT_FOUND, "해당 유저는 보호자가 아닌 환자입니다."
     ),
+    ProtectorHasActivePatientsError(
+            HttpStatus.CONFLICT, "모든 환자가 탈퇴 되지 않았습니다."
+    ),
+
 
     // ----- Location ------
     OutOfBoundaryError(

--- a/src/main/java/org/mansumugang/mansumugang_service/controller/user/UserController.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/controller/user/UserController.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.mansumugang.mansumugang_service.domain.user.User;
 import org.mansumugang.mansumugang_service.dto.user.familyMember.FamilyMemberInquiry;
 import org.mansumugang.mansumugang_service.dto.user.infoDelete.PatientInfoDelete;
+import org.mansumugang.mansumugang_service.dto.user.infoDelete.ProtectorInfoDelete;
 import org.mansumugang.mansumugang_service.dto.user.infoUpdate.PatientInfoUpdate;
 import org.mansumugang.mansumugang_service.dto.user.infoUpdate.ProtectorInfoUpdate;
 import org.mansumugang.mansumugang_service.dto.user.inquiry.PatientInfoInquiry;
@@ -92,6 +93,15 @@ public class UserController {
         PatientInfoDelete.Dto dto = userService.deletePatientInfo(user, patientId);
 
         return new ResponseEntity<>(PatientInfoDelete.Response.createNewResponse(dto), HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/protector/{id}")
+    public ResponseEntity<ProtectorInfoDelete.Response> deleteProtectorInfo(@AuthenticationPrincipal User user,
+                                                                            @PathVariable(name = "id") Long protectorId
+    ){
+        ProtectorInfoDelete.Dto dto = userService.deleteProtectorInfo(user, protectorId);
+
+        return new ResponseEntity<>(ProtectorInfoDelete.Response.createNewResponse(dto), HttpStatus.CREATED);
     }
 
 

--- a/src/main/java/org/mansumugang/mansumugang_service/domain/community/Comment.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/domain/community/Comment.java
@@ -45,6 +45,7 @@ public class Comment {
     Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     Protector protector;
 
 

--- a/src/main/java/org/mansumugang/mansumugang_service/domain/community/Post.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/domain/community/Post.java
@@ -2,6 +2,8 @@ package org.mansumugang.mansumugang_service.domain.community;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.mansumugang.mansumugang_service.domain.user.Protector;
 import org.mansumugang.mansumugang_service.dto.community.post.PostSave;
 import org.mansumugang.mansumugang_service.dto.community.post.PostUpdate;
@@ -41,6 +43,7 @@ public class Post {
 
     // 0. 유저
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Protector protector;
 
     // 1. 카테고리

--- a/src/main/java/org/mansumugang/mansumugang_service/domain/community/PostBookmark.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/domain/community/PostBookmark.java
@@ -30,6 +30,7 @@ public class PostBookmark {
 
     // 2. 유저
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Protector protector;
 
     public static PostBookmark of(Post post, Protector protector){

--- a/src/main/java/org/mansumugang/mansumugang_service/domain/community/PostLike.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/domain/community/PostLike.java
@@ -31,6 +31,7 @@ public class PostLike {
 
     // 2. 유저
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Protector protector;
 
     public static PostLike of(Post post, Protector protector){

--- a/src/main/java/org/mansumugang/mansumugang_service/domain/community/Reply.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/domain/community/Reply.java
@@ -45,6 +45,7 @@ public class Reply {
 
     // 2. 유저
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     Protector protector;
 
     public static Reply of(ReplySave.Request request, Comment foundComment, Protector validProtector){

--- a/src/main/java/org/mansumugang/mansumugang_service/domain/fcm/FcmToken.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/domain/fcm/FcmToken.java
@@ -3,6 +3,8 @@ package org.mansumugang.mansumugang_service.domain.fcm;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.mansumugang.mansumugang_service.domain.user.Protector;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -33,6 +35,7 @@ public class FcmToken {
 
     // Protector 와의 관계 정의
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "protector_id", nullable = false)
     private Protector protector;
 

--- a/src/main/java/org/mansumugang/mansumugang_service/dto/user/infoDelete/ProtectorInfoDelete.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/dto/user/infoDelete/ProtectorInfoDelete.java
@@ -9,10 +9,38 @@ public class ProtectorInfoDelete {
     @Getter
     @AllArgsConstructor
     @Builder
-    public static class Dto{}
+    public static class Dto{
+        private String deletedUsername;
+        private String deletedName;
+        private String usertype;
+
+        public static Dto fromEntity(String username, String name, String usertype){
+            return Dto.builder()
+                    .deletedUsername(username)
+                    .deletedName(name)
+                    .usertype(usertype)
+                    .build();
+        }
+
+    }
 
     @Getter
     @AllArgsConstructor
     @Builder
-    public static class Response{}
+    public static class Response{
+        private String message;
+        private String deletedUsername;
+        private String deletedName;
+        private String usertype;
+
+        public static Response createNewResponse(Dto dto){
+            return Response.builder()
+                    .message("회원 탈퇴가 정상적으로 이루어졌습니다!")
+                    .deletedUsername(dto.getDeletedUsername())
+                    .deletedName(dto.getDeletedName())
+                    .usertype(dto.getUsertype())
+                    .build();
+        }
+
+    }
 }

--- a/src/main/java/org/mansumugang/mansumugang_service/repository/PostRepository.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/repository/PostRepository.java
@@ -15,4 +15,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT DISTINCT p FROM Post p WHERE p.title LIKE %:content% OR p.content LIKE %:content%")
     Page<Post> findByTitleOrContentContaining(@Param("content") String searchContent, Pageable pageable);
+
+    List<Post> findAllByProtectorId(Long protectorId);
 }


### PR DESCRIPTION
내부 로직은 다음과 같습니다.
- 1. 보호자 객체인지 검증
- 2. 경로변수로 찾은 보호자 정보와 현재 기능에 접근한 보호자 정보가 동일한지 검증
- 3. 보호자의 모든 환자가 회원탈퇴가 완료되었는지 검증
- 4. 게시물 이미지를 비롯하여 모든 정보를 DB에서 삭제