### PR TITLE
fix:댓글, 대댓글 삭제 후 조회할 경우 오류에 대한 코드 수정

### DIFF
--- a/src/main/java/org/mansumugang/mansumugang_service/dto/community/comment/CommentInquiry.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/dto/community/comment/CommentInquiry.java
@@ -40,7 +40,7 @@ public class CommentInquiry {
             return CommentElement.builder()
                     .commentId(comment.getId())
                     .postId(comment.getPost().getId())
-                    .profileImageName(comment.getProtector().getProfileImageName() != null && comment.getDeletedAt() == null ? comment.getProtector().getProfileImageName() : null)
+                    .profileImageName(comment.getProtector() != null && comment.getProtector().getProfileImageName() != null && comment.getDeletedAt() == null ? comment.getProtector().getProfileImageName() : null)
                     .creator(comment.getDeletedAt() == null ? comment.getProtector().getNickname() : "알 수 없음")
                     .content(comment.getContent())
                     .createdAt(comment.getCreatedAt())

--- a/src/main/java/org/mansumugang/mansumugang_service/dto/community/reply/ReplyInquiry.java
+++ b/src/main/java/org/mansumugang/mansumugang_service/dto/community/reply/ReplyInquiry.java
@@ -37,7 +37,7 @@ public class ReplyInquiry {
             return ReplyElement.builder()
                     .replyId(reply.getId())
                     .commentId(reply.getComment().getId())
-                    .profileImageName(reply.getProtector().getProfileImageName() != null && reply.getDeletedAt() == null ? reply.getProtector().getProfileImageName() : null)
+                    .profileImageName(reply.getProtector() != null && reply.getProtector().getProfileImageName() != null && reply.getDeletedAt() == null ? reply.getProtector().getProfileImageName() : null)
                     .creator(reply.getDeletedAt() == null ? reply.getProtector().getNickname() : "알 수 없음")
                     .content(reply.getContent())
                     .createdAt(reply.getCreatedAt())


### PR DESCRIPTION
원인은 댓글, 대댓글 삭제 이후 다시 조회할 경우에 프로필 이미지 처리에서 오류가 발생한 것으로 확인되었습니다.

#167 